### PR TITLE
Poloidal plot from node

### DIFF
--- a/notebooks/asdex.ipynb
+++ b/notebooks/asdex.ipynb
@@ -712,6 +712,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "260c04be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "polproj.dpi = 300\n",
+    "polproj.figSize = (8,9)\n",
+    "polproj.reset_insets()\n",
+    "polproj.set_inset(index=0, lowerCornerRelPos=(0.75,0.05),markLoc=[1,2],xlim=[2.12,2.20], ylim=[0.0,0.15], zoom=3.0)\n",
+    "polproj.add_inset(lowerCornerRelPos=(0.3,0.2), xlim=[1.05,1.15], ylim=[-0.30,-0.10], zoom=3.0, markLoc=[2,3])\n",
+    "polproj.add_inset(lowerCornerRelPos=(0.2,0.55), xlim=[1.4,1.7], ylim=[0.8,0.93], zoom=2.5, markLoc=[1,2])\n",
+    "polproj.plot('phi',timeFrame=sim_frames[-1],colorScale='linear',clim=[0,60], colorMap='inferno')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d4ba4c6a",
    "metadata": {},

--- a/notebooks/dev.ipynb
+++ b/notebooks/dev.ipynb
@@ -27,18 +27,17 @@
     "repo_dir = home_dir+'/personal_gkyl_scripts/'\n",
     "# simdir = repo_dir+'sim_data_dir_example/par_adv_test/'\n",
     "# fileprefix = 'rt_gk_tcv_nt_iwl_3x2v_p1'\n",
-    "simdir = '/Users/ahoffman/personal_gkyl_scripts/sim_data_dir_example/3x2v_example/gk_tcv_posD_iwl_3x2v_electron_heating'\n",
-    "fileprefix = 'gk_tcv_posD_iwl_3x2v_D02'\n",
+    "simdir = '/scratch/gpfs/dingyunl/nersc/main/output_3x2v_2'\n",
+    "fileprefix = 'gk_bgk_im_asdex_3x2v_p1'\n",
     "# simdir = '/Users/ahoffman/personal_gkyl_scripts/sim_data_dir_example/3x2v_example/gk_tcv_nt_high_res_geom/'\n",
     "# fileprefix = 'rt_gk_tcv_nt_iwl_3x2v_p1'\n",
     "# simdir = 'sim_data_dir_example/2x2v_example/tcv_NTtq/wk/'\n",
     "# fileprefix = 'gk_tcv_negD_trueq_iwl_2x2v'\n",
     "# simulation = pygkyl.simulation_configs.import_config('tcv_nt', simdir, fileprefix, dimensionality='3x2v')\n",
-    "simulation = pygkyl.simulation_configs.import_config('d3d_nt', simdir, fileprefix)\n",
+    "simulation = pygkyl.simulation_configs.import_config('aug', simdir, fileprefix, load_metric=False)\n",
     "# simulation.geom_param.x_LCFS = 0.08\n",
     "\n",
     "simulation.normalization.set('t','mus') # time in micro-seconds\n",
-    "simulation.normalization.set('x','minor radius') # radial coordinate normalized by the minor radius (rho=r/a)\n",
     "simulation.normalization.set('y','Larmor radius') # binormal in term of reference sound Larmor radius\n",
     "simulation.normalization.set('z','pi') # parallel angle devided by pi\n",
     "simulation.normalization.set('fluid velocities','thermal velocity') # fluid velocity moments are normalized by the thermal velocity\n",
@@ -47,79 +46,45 @@
     "simulation.normalization.set('energies','MJ') # energies in mega Joules\n",
     "simulation.normalization.set('gradients','major radius') # gradients are normalized by the major radius\n",
     "\n",
-    "sim_frames = simulation.available_frames['ion_BiMaxwellianMoments'] # you can check the available frames for each data type like ion_M0, ion_BiMaxwellian, etc.)\n",
+    "sim_frames = simulation.available_frames['field'] # you can check the available frames for each data type like ion_M0, ion_BiMaxwellian, etc.)\n",
     "print(\"%g time frames available (%g to %g)\"%(len(sim_frames),sim_frames[0],sim_frames[-1]))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03c06d90",
+   "id": "5bded661",
    "metadata": {},
    "outputs": [],
    "source": [
-    "torproj = pygkyl.TorusProjection()\n",
-    "torproj.setup(simulation, \n",
-    "              Nint_polproj=24, # number of interpolation points for the poloidal projection\n",
-    "              Nint_fsproj=32, # number of points along the toroidal direction\n",
-    "              phiLim = [0, 3*3.14/2], \n",
-    "              rhoLim = [2,-1]\n",
-    "              )\n"
+    "polproj = pygkyl.PoloidalProjection()\n",
+    "polproj.setup(simulation,nzInterp=32)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5e78d0",
+   "id": "96bc1721",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "torproj.additional_text = {\n",
-    "    'text': '5D simulation of DIII-D\\nnegative triangularity edge plasma\\n(PPPL & General Atomics)',\n",
-    "    'position': 'lower_right',\n",
-    "    'font_size': 12,\n",
-    "    'name': 'title_text'\n",
-    "}\n",
-    "torproj.logo_path = '../gallery/gkeyll_logo.png' # path to the logo image\n",
-    "camera_global = {\n",
-    "'position':(2.5, 2.52, 0.6),\n",
-    "'looking_at':(0.0, -0.2, -0.2),\n",
-    "    'zoom': 1.0\n",
-    "}\n",
-    "camera_zoom_lower = {   \n",
-    "    'position':(0.83, 0.78, -0.1),\n",
-    "    'looking_at':(0., 0.74, -0.19),\n",
-    "    'zoom': 1.0\n",
-    "}\n",
-    "cam1 = camera_global\n",
-    "cam2 = camera_zoom_lower\n",
-    "\n",
-    "if False:\n",
-    "    fieldname = 'ni' # field name to plot\n",
-    "    timeFrame = sim_frames[-1] # time frame to plot\n",
-    "    logScale = True # use logarithmic scale for the color map\n",
-    "    clim = [1e17,2e19] # color map limits\n",
-    "    fluctuation = '' # fluctuation field, if any (e.g., 'yavg')\n",
-    "else:\n",
-    "    fieldname = 'test'\n",
-    "    timeFrame = sim_frames[-1]\n",
-    "    logScale = False\n",
-    "    clim = [0,4] # color map limits for the test field\n",
-    "    fluctuation = '' # fluctuation field, if any (e.g., 'yavg')"
+    "polproj.dpi = 300\n",
+    "polproj.figSize = (8,9)\n",
+    "polproj.reset_insets()\n",
+    "polproj.set_inset(index=0, lowerCornerRelPos=(0.75,0.05),markLoc=[1,2],xlim=[2.12,2.20], ylim=[0.0,0.15], zoom=3.0)\n",
+    "polproj.add_inset(lowerCornerRelPos=(0.3,0.2), xlim=[1.05,1.15], ylim=[-0.30,-0.10], zoom=3.0, markLoc=[2,3])\n",
+    "polproj.add_inset(lowerCornerRelPos=(0.2,0.55), xlim=[1.4,1.7], ylim=[0.8,0.93], zoom=2.5, markLoc=[1,2])\n",
+    "polproj.plot('phi',timeFrame=sim_frames[-1],colorScale='linear',clim=[0,60], colorMap='inferno')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6b91d3c",
+   "id": "bfa3b320",
    "metadata": {},
    "outputs": [],
    "source": [
-    "filePrefix = ''\n",
-    "jupyter_backend='None' # set to 'trame' if you want to use the jupyter backend\n",
-    "torproj.plot(fieldname, timeFrame, clim =clim, logScale = logScale, jupyter_backend=jupyter_backend, \n",
-    "             filePrefix=filePrefix, cameraSettings=cam1,fluctuation=fluctuation)"
+    "kjhgfds"
    ]
   },
   {
@@ -264,7 +229,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -278,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/pygkyl/pygkyl/projections/poloidalprojection.py
+++ b/pygkyl/pygkyl/projections/poloidalprojection.py
@@ -217,7 +217,9 @@ class PoloidalProjection:
     
     elif self.sim.geom_param.geom_type in ['efit', 'Millernodal']:
       simName = self.sim.data_param.fileprefix
-      nodalData = pg.GData(simName+"-nodes_intZ.gkyl")
+      nodefile = simName+"-nodes_intZ.gkyl"
+      if not os.path.isfile(nodefile): nodefile =  simName+"-nodes.gkyl"
+      nodalData = pg.GData(nodefile)
       nodalVals = nodalData.get_values()
       alpha_idx = 0
       if self.sim.geom_param.geom_type == 'efit':
@@ -574,13 +576,13 @@ class PoloidalProjection:
                               pilLoop=pilLoop, pilOptimize=pilOptimize, pilDuration=pilDuration)
       
   def reset_insets(self):
-    self.insets = self.sim.polprojInsets.copy()
     if self.sim.polprojInsets is not None:
       self.insets = self.sim.polprojInsets.copy()
     else:
       self.insets = []
+      
   def set_inset(self, index=0, **kwargs):
-    self.insets[index] = Inset(**kwargs)
+    self.insets[index].set(**kwargs)
       
   def add_inset(self, **kwargs):
     self.insets.append(Inset(**kwargs))
@@ -622,6 +624,11 @@ class Inset:
     self.shading = shading
     self.anchorColorbar = anchorColorbar
     self.markLoc = markLoc
+    
+  def set(self, **kwargs):
+    for key, value in kwargs.items():
+      if hasattr(self, key):
+        setattr(self, key, value)
       
   def add_inset(self, fig, ax, R, Z, fieldRZ, colorMap, colorScale, 
                 minSOL, maxSOL, climInset, logScaleFloor, shading, LCFS=[], limiter=[]):


### PR DESCRIPTION
The poloidal plot can use the geometry from the `-nodes.gkyl` files instead of assuming an analytical expression.
It is highly recommended to initialize a Gkeyll simulation using the same geometry with a higher number of points along Z to provide better accuracy in the final shape of the poloidal plot as the poloidal projector will assume straight lines between the cells.